### PR TITLE
chessground 9.0.4 instead of mliebelt/chessground fork

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@mliebelt/pgn-reader": "^1.2.25",
-        "chessground": "mliebelt/Chessground",
+        "chessground": "^9.0.4",
         "modaly.js": "^0.5.2",
         "mousetrap-ts": "^1.0.0",
         "roddeh-i18n": "^1.2.0",
@@ -1144,9 +1144,9 @@
       "integrity": "sha512-95PsuUCtoxPyQNB+29k54OWGeEEpuWXu+d+oWL/fcko5T5NhDuGxaYmoXcZ6KUnFKyUYxdLjwqRqCWZonRuoJQ=="
     },
     "node_modules/chessground": {
-      "version": "8.2.0",
-      "resolved": "git+ssh://git@github.com/mliebelt/Chessground.git#2043d46eea121cfa8c6a6b84897bc98b5d74950c",
-      "license": "GPL-3.0-or-later",
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/chessground/-/chessground-9.0.4.tgz",
+      "integrity": "sha512-KeZd/kcXSKQOGO6LOKu/3bAyVSMh7hgPPharMF15HMfNlHfcBpIVZIDAQRO2PNaNMzPWl0LKc05uFHt0D+lZGA==",
       "funding": {
         "url": "https://lichess.org/patron"
       }
@@ -6527,8 +6527,9 @@
       "integrity": "sha512-95PsuUCtoxPyQNB+29k54OWGeEEpuWXu+d+oWL/fcko5T5NhDuGxaYmoXcZ6KUnFKyUYxdLjwqRqCWZonRuoJQ=="
     },
     "chessground": {
-      "version": "git+ssh://git@github.com/mliebelt/Chessground.git#2043d46eea121cfa8c6a6b84897bc98b5d74950c",
-      "from": "chessground@mliebelt/Chessground"
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/chessground/-/chessground-9.0.4.tgz",
+      "integrity": "sha512-KeZd/kcXSKQOGO6LOKu/3bAyVSMh7hgPPharMF15HMfNlHfcBpIVZIDAQRO2PNaNMzPWl0LKc05uFHt0D+lZGA=="
     },
     "chokidar": {
       "version": "3.5.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@mliebelt/pgn-reader": "^1.2.25",
-    "chessground": "mliebelt/Chessground",
+    "chessground": "^9.0.4",
     "modaly.js": "^0.5.2",
     "mousetrap-ts": "^1.0.0",
     "roddeh-i18n": "^1.2.0",

--- a/src/pgnv.ts
+++ b/src/pgnv.ts
@@ -1,8 +1,8 @@
 import {Chessground} from 'chessground'
 import {Color} from "chessground/types";
 import {Config} from "chessground/config";
-import 'chessground/assets/chessground.base.css'
-import 'chessground/assets/chessground.brown.css'
+import '../node_modules/chessground/assets/chessground.base.css'
+import '../node_modules/chessground/assets/chessground.brown.css'
 import Mousetrap from 'mousetrap-ts'
 const Modaly = require('modaly.js')
 import {PgnReader, Shape, Field, PgnReaderMove, GameComment} from '@mliebelt/pgn-reader'


### PR DESCRIPTION
I have tried to use new `chessground` instead of `mliebelt/chessground` built.

It works, but it is a little ugly.

I am not experienced NodeJS nor javascript programmer, so it can be probably solved better?
