### PR TITLE
Fix board CSS class manipulation

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -16,7 +16,12 @@ export type Base = {
 }
 
 export type  SupportedLocales = 'en' |  'de' |  'fr' |  'es' |  'cs' |  'da' |  'et' |  'fi' |  'hu' |  'is' |  'it' |  'nb' |  'nl' |  'pt' |  'ro' |  'sv'
-export type Layout = 'left'|'right'|'top'|'bottom'
+export enum Layout {
+    Left = 'left',
+    Right = 'right',
+    Top = 'top',
+    Bottom = 'bottom',
+}
 export type Color = 'white' | 'black'
 export type ShortColor = 'w' | 'b'
 export type TimeAnnotation = {
@@ -34,7 +39,12 @@ export type PgnBoardConfiguration = {
     drawable?: boolean
 }
 
-export type PgnViewerMode = 'board' | 'view' | 'edit' | 'print'
+export enum PgnViewerMode {
+    Board = 'board',
+    View = 'view',
+    Edit = 'edit',
+    Print = 'print',
+}
 
 export type PgnViewerConfiguration = {
     modalClicked?: (value: ("q" | "r" | "b" | "n")) => void;
@@ -42,7 +52,7 @@ export type PgnViewerConfiguration = {
     mode?:PgnViewerMode,
     IDs?:{ [key in PgnViewerID]?: string },
     pgn?:string,
-    theme?:string,
+    theme?:Theme,
     figurine?:string,
     layout?:Layout,
     resizable?:boolean,
@@ -96,4 +106,16 @@ export enum PieceStyle {
     Merida = 'merida',
     Leipzig = 'leipzig',
     Beyer = 'beyer',
+}
+
+export enum Theme {
+    Default = 'default',
+    Zeit = 'zeit',
+    Green = 'green',
+    Blue = 'blue',
+    Falken = 'falken',
+    Beyer = 'beyer',
+    Sportverlag = 'sportverlag',
+    Informator = 'informator',
+    Brown = 'brown',
 }


### PR DESCRIPTION
Similar to https://github.com/mliebelt/pgn-viewer/pull/476, but more generically, it fixes the board CSS class manipulation for the following (on top of piece style):
- theme
- layout
- mode

If I'm not wrong, all of them are now using `divBoard.classList.add`, which makes it end up in a situation where more than one exclusive value is present (more details in the aforementioned pull request), breaking the application.

You'll see I did the trick with a some TypeScript generics, in order to re-use code, but I'd be happy to simplify if by copy-pasting one function for each type. Similar for the enums, and for the heuristics. I'll be happy to apply any code suggestion you have that achieves the same behavior, but that's the best I could do so far.

I hope it helps! At least, it would really unblock the use I'm planning to for this amazing library! 💟 

Thanks!