### PR TITLE
Fix of issue #522

### DIFF
--- a/src/pgnv.ts
+++ b/src/pgnv.ts
@@ -846,7 +846,9 @@ let pgnBase = function (boardId:string, configuration:PgnViewerConfiguration) {
         // TODO: The 'san' tag is not valid typed, but how to do that for custom elements
         const _linkEle = createEle('san' as keyof HTMLElementTagNameMap, null, null, null, _moveSpan)
         let _san = ""
-        if (move.notation && move.notation.fig) {
+        if (hasMode(PgnViewerMode.Puzzle)){
+            _san = that.mypgn.getMove(move.index).notation.notation
+	} else if (move.notation && move.notation.fig) {
             const locale = that.configuration.locale
             const figurine = that.configuration.figurine
             const fig = (!locale || figurine) ? move.notation.fig : t("chess:" + move.notation.fig)


### PR DESCRIPTION
Added fix to regenerateMoveSpan, SAN is directly read from pgn in puzzle mode, otherwise the FEN gets messed up when calling pgnReader.